### PR TITLE
Create provider.md

### DIFF
--- a/provider.md
+++ b/provider.md
@@ -2,7 +2,7 @@
 
 ## 阿里云
 
-bailian.console.aliyun.com
+https://bailian.console.aliyun.com
 
 - qwen-vl-max: 
   - ￥3/M输入 

--- a/provider.md
+++ b/provider.md
@@ -25,8 +25,8 @@ bailian.console.aliyun.com
 https://ai.google.dev/
 
 - gemini-2.5-pro
-  - \$1.25/M输入（输入<= 200k tokens） \$2.50/M输入（输入> 200k tokens）
-  - \$10.00/M输出（输入<= 200k tokens） \$15.00/M输出（输入> 200k tokens）（包括思维链）
+  - 免费
+  - 免费
   - 谷歌的视觉模型，支持Markdown和LaTex识别和排版
 - gemini-2.5-flash
   - 免费

--- a/provider.md
+++ b/provider.md
@@ -1,0 +1,16 @@
+# 模型提供商
+
+## 阿里云
+- qwen-vl-max: 
+  - ￥3/M输入 ￥9/M输出
+  - 支持Markdown和LaTex识别和排版，对手写体也有较高的准确率
+- qwen-vl-plus:
+  - ￥1.5/M输入 ￥4.5/M输出
+  - 不支持Markdown和LaTex识别，可以识别纯文本
+- qwen-vl-ocr:
+  - ￥5/M输入
+  - 支持Markdown和LaTex识别，速度奇快
+- qvq-plus:
+  - ￥2/M输入 ￥5/M输出（包括思维链）
+  - 视觉推理模型，支持Markdown和LaTex识别 ~~杀鸡用牛刀？~~
+

--- a/provider.md
+++ b/provider.md
@@ -1,16 +1,47 @@
 # 模型提供商
 
 ## 阿里云
+
+bailian.console.aliyun.com
+
 - qwen-vl-max: 
-  - ￥3/M输入 ￥9/M输出
+  - ￥3/M输入 
+  - ￥9/M输出
   - 支持Markdown和LaTex识别和排版，对手写体也有较高的准确率
 - qwen-vl-plus:
-  - ￥1.5/M输入 ￥4.5/M输出
+  - ￥1.5/M输入 
+  - ￥4.5/M输出
   - 不支持Markdown和LaTex识别，可以识别纯文本
 - qwen-vl-ocr:
   - ￥5/M输入
   - 支持Markdown和LaTex识别，速度奇快
 - qvq-plus:
-  - ￥2/M输入 ￥5/M输出（包括思维链）
+  - ￥2/M输入 
+  - ￥5/M输出（包括思维链）
   - 视觉推理模型，支持Markdown和LaTex识别 ~~杀鸡用牛刀？~~
 
+## Gemini
+
+https://ai.google.dev/
+
+- gemini-2.5-pro
+  - \$1.25/M输入（输入<= 200k tokens） \$2.50/M输入（输入> 200k tokens）
+  - \$10.00/M输出（输入<= 200k tokens） \$15.00/M输出（输入> 200k tokens）（包括思维链）
+  - 谷歌的视觉模型，支持Markdown和LaTex识别和排版
+- gemini-2.5-flash
+  - 免费
+  - 免费
+  - 谷歌的视觉模型，支持Markdown和LaTex识别和排版
+
+## OpenAI
+
+https://platform.openai.com/
+
+- gpt-4o-2024-08-06
+  - \$2.50/M输入（未命中缓存） $1.25/M输入（命中缓存）
+  - \$10.00/M输出
+  -
+- gpt-4o-mini-2024-07-18
+  - \$0.15/M输入（未命中缓存） $0.075/M输入（命中缓存）
+  - \$0.60/M输出
+  - 


### PR DESCRIPTION
This pull request adds a new section to the `provider.md` file, detailing various AI model providers, their offerings, pricing, and features.

### Additions to `provider.md`:

#### New AI Model Providers:

* **阿里云**:
  - Introduced multiple models (`qwen-vl-max`, `qwen-vl-plus`, `qwen-vl-ocr`, `qvq-plus`) with specific pricing and capabilities, including Markdown/LaTeX recognition and visual reasoning.

* **Gemini**:
  - Added Google's AI models (`gemini-2.5-pro`, `gemini-2.5-flash`) with pricing tiers and support for Markdown/LaTeX recognition and formatting.

* **OpenAI**:
  - Listed OpenAI's models (`gpt-4o-2024-08-06`, `gpt-4o-mini-2024-07-18`) with caching-based pricing and token limits.